### PR TITLE
Added tests for token failure conditions and captured a new error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ export default class Auth {
 				this.refreshIdToken()
 					.then(() => this.fetchProfile())
 					.catch(e => {
-						if (e.message === 'TOKEN_EXPIRED') return this.signOut();
+						if (e.message === 'TOKEN_EXPIRED' || e.message === 'INVALID_ID_TOKEN') return this.signOut();
 						throw e;
 					});
 		});

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -166,6 +166,68 @@ describe('Auth', () => {
 			expect(fetch.mock.calls.length).toEqual(0);
 		});
 
+		test('Signs out a previously signed in user when their token has expired', async () => {
+			// Previously signed in user
+			localStorage.setItem(
+				'Auth:User:key:default',
+				JSON.stringify({
+					email: 'test@example.com',
+					tokenManager: {
+						idToken: 'idTokenString',
+						expiresAt: Date.now()
+					}
+				})
+			);
+			fetch.mockResponse('{"error": {"message": "TOKEN_EXPIRED"}}', { status: 403 });
+			let auth;
+			let user;
+			const constructor = new Promise(resolve => {
+				auth = new Auth({ apiKey: 'key' });
+
+				// Wait for requests to be made.
+				// We need this because the constructor can't be async.
+				setTimeout(resolve, 1000);
+			});
+
+			auth.listen(authUser => {
+				user = user;
+			});
+			await constructor;
+			expect(fetch.mock.calls.length).toEqual(1);
+			expect(user).toBe(undefined);
+		});
+
+		test('Signs out a previously signed in user when their token is invalid', async () => {
+			// Previously signed in user
+			localStorage.setItem(
+				'Auth:User:key:default',
+				JSON.stringify({
+					email: 'test@example.com',
+					tokenManager: {
+						idToken: 'idTokenString',
+						expiresAt: Date.now()
+					}
+				})
+			);
+			fetch.mockResponse('{"error": {"message": "INVALID_ID_TOKEN"}}', { status: 403 });
+			let auth;
+			let user;
+			const constructor = new Promise(resolve => {
+				auth = new Auth({ apiKey: 'key' });
+
+				// Wait for requests to be made.
+				// We need this because the constructor can't be async.
+				setTimeout(resolve, 1000);
+			});
+
+			auth.listen(authUser => {
+				user = user;
+			});
+			await constructor;
+			expect(fetch.mock.calls.length).toEqual(1);
+			expect(user).toBe(undefined);
+		});
+
 		describe('Storage events listener', () => {
 			test('updates the instance user data', () => {
 				const auth = new Auth({ apiKey: 'key' });


### PR DESCRIPTION
I was encountering the error of `INVALID_ID_TOKEN` as well as TOKEN_EXPIRED.  I think this change fixes both cases. I've also added tests.

The constructor being async is really frustrating because you can't catch any exceptions that happen inside of it. I wonder if there's a different pattern we could apply here? Anyway this should fix the current issue I'm facing.