### PR TITLE
fix: Prevent trailing white space in error codes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,7 +125,7 @@ export default class Auth {
 			// Sometimes the error codes are joined with an explanation, we don't need that(its a bug).
 			// So we remove the unnecessary part.
 			if (!response.ok) {
-				const code = data.error.message.replace(/: [\w ,.'"()]+$/, '');
+				const code = data.error.message.replace(/: [\w ,.'"()]+$/, '').trim();
 				throw Error(code);
 			}
 


### PR DESCRIPTION
Some (maybe all) error messages comes with a white space before the explication of the message. The regex strips everything after `:` but not the space before it.
One example of this is the "Too many attemps" error that yields the following:

> "TOO_MANY_ATTEMPTS_TRY_LATER : Too many unsuccessful login attempts. Please try again later."

Applying your regexp it returns: "TOO_MANY_ATTEMPTS_TRY_LATER ".

I'm not sure what's more efficient between altering the regexp to handle that case or using `.trim()` on the final message.