### PR TITLE
feat: Developer can now force the IdToken Refresh

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -168,11 +168,12 @@ export default class Auth {
 
 	/**
 	 * Refreshes the idToken by using the locally stored refresh token only if the idToken has expired.
+	 * @param {boolean} [forceRefresh = false] Force IdToken Refresh.
 	 * @private
 	 */
-	async refreshIdToken() {
+	async refreshIdToken(forceRefresh = false) {
 		// If the idToken didn't expire, return.
-		if (Date.now() < this.user.tokenManager.expiresAt) return;
+		if (Date.now() < this.user.tokenManager.expiresAt && !forceRefresh) return;
 
 		// If the request for a new token was already made, then wait for it and return.
 		if (this._ref) return void (await this._ref);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -476,6 +476,16 @@ describe('Auth', () => {
 			expect(fetch.mock.calls.length).toEqual(0);
 		});
 
+		test('Force refresh token even if the token is still valid', async () => {
+			fetch.mockResponse('{"users": [{ "updated": true }]}');
+			
+			const auth = new Auth({ apiKey: 'key' });
+			await mockLoggedIn(auth);
+			await auth.refreshIdToken(true);
+
+			expect(fetch.mock.calls.length).toEqual(1);
+		});
+
 		test('Allow only one concurrent fetch request', async () => {
 			// The constructor makes some requests.
 			// We have to mock them for this not to throw


### PR DESCRIPTION
Sometimes we need to force the IdToken Refresh and we just realized that wasn't possible. Just added a parameter to the `refreshIdToken()` function to force the refresh, even if the token is still valid.

Our use case:

When a new user is created, we trigger a firebase callable function to set custom claims in the firebase auth user, after setting these claims we need to refresh the idToken to start making requests with these custom claims set.

That's possible with the official library with `auth.currentUser.getIdToken(true)`, so, with firebase-auth-lite we can just do `auth.refreshIdToken(true)`.

There's no breaking changes.