### PR TITLE
fix: let `sendOobCode` return errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -375,7 +375,7 @@ export default class Auth {
 			email = this.user.email;
 		}
 
-		return void this.api('sendOobCode', {
+		return this.api('sendOobCode', {
 			idToken: verifyEmail ? this.user.tokenManager.idToken : undefined,
 			requestType,
 			email,


### PR DESCRIPTION
Because of the `void` return in `sendOobCode`, errors are not propagated and cannot be caught and handles in the UI.

This happens when sending an oob code to reset a password on a non existing email.
```js
import Auth from 'firebase-auth-lite';

const auth = new Auth({ apiKey });
auth.sendOobCode('PASSWORD_RESET', 'invalid@email.com);
```

This change only removes the `void` keyword.